### PR TITLE
added {}-brackets

### DIFF
--- a/Measure.Domain/DTOs/ReadDTO/ReadUserCridentialsDto.cs
+++ b/Measure.Domain/DTOs/ReadDTO/ReadUserCridentialsDto.cs
@@ -13,4 +13,5 @@ namespace Measure.Domain.DTOs.ReadDTO
         string Username,
         string Email,
         string Password)
+    { }
 }


### PR DESCRIPTION
missing {} when ReadUserCridentialsDto was created. Has now been added